### PR TITLE
Env-driven API URLs + Clerk keys for mobile apps (QA/prod EAS profiles)

### DIFF
--- a/apps/client-mobile/app.config.ts
+++ b/apps/client-mobile/app.config.ts
@@ -1,6 +1,7 @@
 import type { ConfigContext, ExpoConfig } from "expo/config";
 
 const CLERK_PUBLISHABLE_KEY =
+  process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY ??
   "pk_test_bW9kZXJuLWZlbGluZS0xMS5jbGVyay5hY2NvdW50cy5kZXYk";
 
 export default ({ config }: ConfigContext): ExpoConfig => ({

--- a/apps/client-mobile/app/_layout.tsx
+++ b/apps/client-mobile/app/_layout.tsx
@@ -31,10 +31,11 @@ export default function RootLayout() {
     // Async font loading only occurs in development.
     return null;
   }
-  // TODO: add qa/prod publishable keys
+  // Set per build profile in eas.json (EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY); falls back to QA.
   return (
     <ClerkProvider
       publishableKey={
+        process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY ??
         "pk_test_bW9kZXJuLWZlbGluZS0xMS5jbGVyay5hY2NvdW50cy5kZXYk"
       }
       tokenCache={tokenCache}

--- a/apps/client-mobile/eas.json
+++ b/apps/client-mobile/eas.json
@@ -6,13 +6,25 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://app-qa.eboxsecure.com",
+        "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY": "pk_test_bW9kZXJuLWZlbGluZS0xMS5jbGVyay5hY2NvdW50cy5kZXYk"
+      }
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://app-qa.eboxsecure.com",
+        "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY": "pk_test_bW9kZXJuLWZlbGluZS0xMS5jbGVyay5hY2NvdW50cy5kZXYk"
+      }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "environment": "production",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://app.eboxsecure.com"
+      }
     }
   },
   "submit": {

--- a/apps/client-mobile/trpc/react.tsx
+++ b/apps/client-mobile/trpc/react.tsx
@@ -81,8 +81,7 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
 }
 
 const getBaseUrl = () => {
-  // if (typeof window !== "undefined") return window.location.origin;
-  // TODO: change to real base url
-  return `https://app-qa.eboxsecure.com`;
+  // Set per build profile in eas.json (EXPO_PUBLIC_API_URL); falls back to QA.
+  return process.env.EXPO_PUBLIC_API_URL ?? `https://app-qa.eboxsecure.com`;
   // return `http://localhost:3000`;
 };

--- a/apps/mobile-scanner/app/_layout.tsx
+++ b/apps/mobile-scanner/app/_layout.tsx
@@ -21,10 +21,13 @@ export default function RootLayout() {
     return null;
   }
 
-  // TODO: add qa/prod publishable keys
+  // Set per build profile in eas.json (EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY); falls back to QA.
   return (
     <ClerkProvider
-      publishableKey={"pk_test_YmVsb3ZlZC1nbmF0LTM3LmNsZXJrLmFjY291bnRzLmRldiQ"}
+      publishableKey={
+        process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY ??
+        "pk_test_YmVsb3ZlZC1nbmF0LTM3LmNsZXJrLmFjY291bnRzLmRldiQ"
+      }
       tokenCache={tokenCache}
     >
       <SessionTimeoutWrapper>

--- a/apps/mobile-scanner/eas.json
+++ b/apps/mobile-scanner/eas.json
@@ -9,13 +9,25 @@
       "distribution": "internal",
       "ios": {
         "simulator": true
+      },
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://admin-qa.eboxsecure.com",
+        "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY": "pk_test_YmVsb3ZlZC1nbmF0LTM3LmNsZXJrLmFjY291bnRzLmRldiQ"
       }
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://admin-qa.eboxsecure.com",
+        "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY": "pk_test_YmVsb3ZlZC1nbmF0LTM3LmNsZXJrLmFjY291bnRzLmRldiQ"
+      }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "environment": "production",
+      "env": {
+        "EXPO_PUBLIC_API_URL": "https://admin.eboxsecure.com"
+      }
     }
   },
   "submit": {

--- a/apps/mobile-scanner/trpc/react.tsx
+++ b/apps/mobile-scanner/trpc/react.tsx
@@ -81,8 +81,7 @@ export function TRPCReactProvider(props: { children: React.ReactNode }) {
 }
 
 const getBaseUrl = () => {
-  // if (typeof window !== "undefined") return window.location.origin;
-  // TODO: change to real base url
-  return `https://admin-qa.eboxsecure.com`;
+  // Set per build profile in eas.json (EXPO_PUBLIC_API_URL); falls back to QA.
+  return process.env.EXPO_PUBLIC_API_URL ?? `https://admin-qa.eboxsecure.com`;
   // return `http://localhost:3000`;
 };


### PR DESCRIPTION
## What

Removes the hardcoded QA base URLs and Clerk test keys from `client-mobile` and `mobile-scanner` so we can cut **production builds pointing at prod** for the demo and App Store launch.

- `getBaseUrl()` now reads `EXPO_PUBLIC_API_URL` (falls back to the QA URL — local dev unchanged)
- `ClerkProvider` `publishableKey` now reads `EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY` (falls back to the existing test key)
- `eas.json` per-profile env:
  - `development` / `preview` → QA URLs + Clerk test keys (current behavior, now explicit)
  - `production` → `https://app.eboxsecure.com` / `https://admin.eboxsecure.com`, `"environment": "production"` so the live Clerk key comes from EAS env vars

## Before merging / building prod

- [ ] **Confirm the admin portal prod URL** — `admin.eboxsecure.com` is inferred from the `app-qa` → `app` pattern; it isn't in the repo anywhere
- [ ] Set the live Clerk key in EAS for **both** apps: `eas env:create --environment production --name EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY --value pk_live_...`

## Verified

- `tsc --noEmit` clean on edited files in both apps
- QA fallbacks preserve current behavior for dev/preview builds with no env set