### PR TITLE
Fix employee dashboard metrics (Processed Today always 0)

### DIFF
--- a/apps/admin-portal/src/app/(home)/_components/employee-home.tsx
+++ b/apps/admin-portal/src/app/(home)/_components/employee-home.tsx
@@ -13,7 +13,7 @@ export function EmployeeHome() {
 
   // Fetch recent orders for the employee's location
   const { data: recentOrders, isLoading: isLoadingOrders } =
-    api.order.getAllOrdersForEmployee.useQuery();
+    api.orders.getAllOrdersForEmployee.useQuery();
 
   // Get quick stats for employee dashboard
   const pendingDeliveries =

--- a/packages/admin-api/src/router/orders.ts
+++ b/packages/admin-api/src/router/orders.ts
@@ -118,6 +118,28 @@ export const ordersRouter = createTRPCRouter({
       }
     }),
 
+  getAllOrdersForEmployee: protectedAdminProcedure.query(async ({ ctx }) => {
+    // Return ALL orders scoped to the current employee's location. The
+    // dashboard computes its metrics client-side (counts, "processed today",
+    // recent activity), so this intentionally is NOT paginated.
+    const whereClause = {
+      shippedLocation: {
+        employeeAccounts: {
+          some: {
+            id: ctx.session.userId,
+          },
+        },
+      },
+    };
+
+    return await ctx.db.order.findMany({
+      where: whereClause,
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+  }),
+
   getOrderDetails: protectedAdminProcedure
     .input(
       z.object({


### PR DESCRIPTION
## Problem
The admin-portal employee dashboard rendered `0` for all four metric cards (Pending Deliveries, Ready for Pickup, **Processed Today**, Total Orders) and an empty Recent Activity list, even after packages were processed today.

## Root cause
`apps/admin-portal/.../_components/employee-home.tsx` called `api.order.getAllOrdersForEmployee.useQuery()`, which is broken two ways:

1. The admin `appRouter` (`packages/admin-api/src/root.ts`) registers the orders router under the key **`orders`** (plural), not `order`.
2. No `getAllOrdersForEmployee` procedure existed anywhere — the orders router only had `getAllOrders`, `getOrderDetails`, and `markOrderAsPickedUp`.

Because `apps/admin-portal/next.config.js` sets `typescript.ignoreBuildErrors = true`, this shipped. At runtime the query resolved to a nonexistent tRPC path, so `recentOrders` was `undefined` and every derived metric fell through to `0`/empty. The underlying data was fine — `processedAt` is written correctly by the scanner (`packages/admin-api/src/router/scanner.ts`).

## Fix
1. Added a `getAllOrdersForEmployee` `protectedAdminProcedure` to `packages/admin-api/src/router/orders.ts`. It returns **all** orders scoped to the current employee's location (`shippedLocation.employeeAccounts.some.id === ctx.session.userId`, reusing the existing `getAllOrders` employee-scoping pattern), ordered by `createdAt` desc, **not paginated** (the dashboard counts client-side and slices the first 5 for Recent Activity). It returns full order rows, so every field the component reads — `id`, `processedAt`, `deliveredDate`, `pickedUpAt`, `createdAt` — is present.
2. Updated `employee-home.tsx` to call `api.orders.getAllOrdersForEmployee.useQuery()` (plural).

## Files changed
- `packages/admin-api/src/router/orders.ts`
- `apps/admin-portal/src/app/(home)/_components/employee-home.tsx`

## Validation
Ran in the worktree (offline install per repo tooling gotchas):
- `pnpm install --offline --ignore-scripts` — ok
- `pnpm -F db generate` — ok (Prisma client generated)
- `pnpm -F @ebox/admin-api build` — rebuilt `dist/*.d.ts` so admin-portal typechecks against fresh types. Fails **only** on 2 pre-existing errors in `src/router/auth.test.ts` (mock order objects missing new Shopify fields `shopifyOrderId`/`shopifyShop`/`sourceChannel`/`cancelledAt`/`cancelReason`) — that test file is not part of this change. `dist` still emitted the new procedure.
- `pnpm -F @ebox/admin-api typecheck` — **no errors in `orders.ts`**; only the same 2 pre-existing `auth.test.ts` errors.
- `pnpm -F @ebox/admin-portal typecheck` — **no errors in `employee-home.tsx`**, confirming `api.orders.getAllOrdersForEmployee` resolves and all consumed fields typecheck. Remaining errors are all pre-existing and in unmodified files (`next.config.js`, `seed-analytics.ts`, `customers/customer-details/[clientId]/page.tsx`, `sign-in/[[...sign-in]]/page.tsx`).
- `pnpm lint` skipped — broken repo-wide (pre-existing eslint 9 issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)