### PR TITLE
Remove dead Finances nav items from admin sidebar

### DIFF
--- a/apps/admin-portal/src/app/_components/sidebar.tsx
+++ b/apps/admin-portal/src/app/_components/sidebar.tsx
@@ -53,17 +53,6 @@ const allOperations = [
   },
 ];
 
-const finances = [
-  {
-    title: "Payments",
-    url: "#",
-  },
-  {
-    title: "Subscriptions",
-    url: "#",
-  },
-];
-
 const AppSidebar = () => {
   const { data: userType, isLoading } = api.user.getUserType.useQuery();
   const { data: userDetails, isLoading: isLoadingDetails } =
@@ -123,22 +112,6 @@ const AppSidebar = () => {
           <SidebarGroupLabel>Operations</SidebarGroupLabel>
           <SidebarMenu>
             {visibleOperations.map((item) => (
-              <SidebarMenuItem key={item.title}>
-                <SidebarMenuButton asChild>
-                  <a href={item.url}>
-                    <span>{item.title}</span>
-                  </a>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
-            ))}
-          </SidebarMenu>
-        </SidebarGroup>
-        <SidebarSeparator />
-
-        <SidebarGroup>
-          <SidebarGroupLabel>Finances</SidebarGroupLabel>
-          <SidebarMenu>
-            {finances.map((item) => (
               <SidebarMenuItem key={item.title}>
                 <SidebarMenuButton asChild>
                   <a href={item.url}>


### PR DESCRIPTION
## What

Removes the dead **Payments** and **Subscriptions** buttons from the "Finances" section of the admin portal sidebar.

## Why

Both buttons were rendered from a `finances` array whose entries pointed at `url: "#"`. A grep of `apps/admin-portal/src/app` confirmed there are **no `payments` or `subscriptions` routes or page files** — the only other `subscriptions` match is an unrelated local filter state variable in `customers-table.tsx`. The buttons therefore led nowhere and were pure dead UI.

## Changes (single file: `apps/admin-portal/src/app/_components/sidebar.tsx`)

- Deleted the `finances` array declaration.
- Deleted the entire "Finances" `<SidebarGroup>` block that mapped over it.
- Deleted the now-redundant `<SidebarSeparator />` that immediately preceded it (avoids a dangling separator).

The remaining JSX is balanced: Home group → separator → Operations group → footer, all untouched. `SidebarSeparator` is still imported and used after the Home group, so no imports became unused.

## Validation

- `pnpm install --offline --ignore-scripts` + `pnpm -F db generate`
- `pnpm -F @ebox/admin-portal typecheck` — zero errors reference `sidebar.tsx`. The 15 pre-existing repo-wide type errors are identical before and after this change (verified via `git stash`), so this introduces no new errors.
- `pnpm lint` skipped (broken repo-wide, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)