### PR TITLE
Guard Create Location button to corporate users only

### DIFF
--- a/apps/admin-portal/src/app/(home)/locations/page.tsx
+++ b/apps/admin-portal/src/app/(home)/locations/page.tsx
@@ -1,3 +1,4 @@
+import { UserType } from "@prisma/client";
 import { Plus } from "lucide-react";
 
 import { Button } from "@ebox/ui/button";
@@ -9,6 +10,7 @@ import { api } from "~/trpc/server";
 export default async function LocationsPage() {
   try {
     const locations = await api.locations.getAllLocations();
+    const userType = await api.user.getUserType();
 
     return (
       <main className="container h-screen w-full py-16 md:w-9/12">
@@ -16,12 +18,14 @@ export default async function LocationsPage() {
           <div className="w-full">
             <div className="my-4 flex items-center justify-between">
               <p className="font-medium">Locations</p>
-              <CreateLocationDialog>
-                <Button>
-                  <Plus className="mr-2 h-4 w-4" />
-                  Create Location
-                </Button>
-              </CreateLocationDialog>
+              {userType === UserType.CORPORATE && (
+                <CreateLocationDialog>
+                  <Button>
+                    <Plus className="mr-2 h-4 w-4" />
+                    Create Location
+                  </Button>
+                </CreateLocationDialog>
+              )}
             </div>
             <LocationsTable locations={locations} />
           </div>


### PR DESCRIPTION
## Problem

On the admin portal **Locations** page, every employee — regardless of user type — saw the **Create Location** button and could fill out the entire dialog. The request only failed on submit with `Only corporate users can create locations`. That is a confusing, dead-end UX for non-corporate users.

## Fix

`apps/admin-portal/src/app/(home)/locations/page.tsx` is an async server component that already fetches `api.locations.getAllLocations()`. This PR:

- Also fetches the user type server-side via the existing `api.user.getUserType()` procedure.
- Imports `UserType` from `@prisma/client`.
- Renders the `<CreateLocationDialog>` / `Create Location` button **only** when `userType === UserType.CORPORATE`.
- For non-corporate users, the header row still renders with just the "Locations" title (`justify-between` keeps the layout tidy).
- The existing `try/catch` and error UI are untouched.

## Defense in depth

This is a UI guard only — the server already enforces the same rule. The `createLocation` mutation in `packages/admin-api/src/router/locations.ts` (lines 234-249) rejects any non-corporate caller with a `TRPCError`:

```ts
if (userType?.userType !== UserType.CORPORATE) {
  throw new TRPCError({
    code: "UNAUTHORIZED",
    message: "Only corporate users can create locations",
  });
}
```

That server guard is the source of the current error message and remains the authoritative check. This PR just prevents non-corporate users from ever reaching a request that is guaranteed to fail.

## Validation

- `pnpm install --offline --ignore-scripts` then `pnpm -F db generate` (repo setup)
- `pnpm -F @ebox/admin-portal typecheck` — the set of `tsc --noEmit` errors is **identical** (same output hash) with and without this change; every reported error is pre-existing and unrelated to `locations/page.tsx`. This change introduces zero new type errors.
- `pnpm lint` intentionally not run (broken repo-wide, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)