### PR TITLE
Show employee role and scoped location in admin header

### DIFF
--- a/apps/admin-portal/src/app/_components/navbar/index.tsx
+++ b/apps/admin-portal/src/app/_components/navbar/index.tsx
@@ -1,10 +1,13 @@
 import NotificationDropdown from "./notification-dropdown";
 import { PickupQRScannerButton } from "./pickup-qr-scanner";
 import { SearchForm } from "./search-form";
+import { UserScopeBadge } from "./user-scope-badge";
 
 const Navbar = () => {
   return (
-    <header className="fixed top-0 z-50 flex h-[--header-height] w-full items-center bg-secondary px-6 py-4">
+    <header className="fixed top-0 z-50 flex h-[--header-height] w-full items-center gap-4 bg-secondary px-6 py-4">
+      <UserScopeBadge />
+
       <div className="ml-auto flex items-center gap-2">
         <PickupQRScannerButton />
 

--- a/apps/admin-portal/src/app/_components/navbar/user-scope-badge.tsx
+++ b/apps/admin-portal/src/app/_components/navbar/user-scope-badge.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { EmployeeRole, UserType } from "@prisma/client";
+import { Building2, MapPin } from "lucide-react";
+
+import { Badge } from "@ebox/ui/badge";
+
+import { api } from "~/trpc/react";
+
+const employeeRoleLabels: Record<EmployeeRole, string> = {
+  [EmployeeRole.MANAGER]: "Manager",
+  [EmployeeRole.ASSOCIATE]: "Associate",
+};
+
+export function UserScopeBadge() {
+  const { data: userDetails, isLoading } =
+    api.user.getCurrentUserDetails.useQuery();
+
+  // Don't render anything while loading.
+  if (isLoading || !userDetails) {
+    return null;
+  }
+
+  // Corporate users are not scoped to a single location.
+  if (userDetails.userType === UserType.CORPORATE) {
+    return (
+      <Badge
+        variant="secondary"
+        className="gap-1.5 whitespace-nowrap bg-white/80 text-secondary-foreground"
+      >
+        <Building2 className="h-3.5 w-3.5 shrink-0" />
+        <span className="font-semibold">Corporate</span>
+        <span className="text-muted-foreground">·</span>
+        <span className="font-normal">All locations</span>
+      </Badge>
+    );
+  }
+
+  // Employees are limited to a single location.
+  if (
+    userDetails.userType === UserType.EMPLOYEE &&
+    userDetails.employeeRole
+  ) {
+    const roleLabel = employeeRoleLabels[userDetails.employeeRole];
+    const locationName = userDetails.locationName ?? "Unknown location";
+
+    return (
+      <Badge
+        variant="secondary"
+        className="gap-1.5 whitespace-nowrap bg-white/80 text-secondary-foreground"
+        title={
+          userDetails.locationCity
+            ? `${roleLabel} · ${locationName}, ${userDetails.locationCity}`
+            : `${roleLabel} · ${locationName}`
+        }
+      >
+        <span className="font-semibold">{roleLabel}</span>
+        <span className="text-muted-foreground">·</span>
+        <MapPin className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="max-w-[10rem] truncate font-normal">
+          {locationName}
+        </span>
+      </Badge>
+    );
+  }
+
+  // Plain customer / unknown user type: render nothing.
+  return null;
+}
+
+export default UserScopeBadge;

--- a/packages/admin-api/src/router/user.ts
+++ b/packages/admin-api/src/router/user.ts
@@ -52,6 +52,13 @@ export const userRouter = createTRPCRouter({
             select: {
               employeeRole: true,
               locationId: true,
+              location: {
+                select: {
+                  name: true,
+                  city: true,
+                  address: true,
+                },
+              },
             },
           },
         },
@@ -69,6 +76,9 @@ export const userRouter = createTRPCRouter({
           userType: user.userType,
           employeeRole: user.employeeAccount.employeeRole,
           locationId: user.employeeAccount.locationId,
+          locationName: user.employeeAccount.location.name,
+          locationCity: user.employeeAccount.location.city,
+          locationAddress: user.employeeAccount.location.address,
         };
       }
 
@@ -76,6 +86,9 @@ export const userRouter = createTRPCRouter({
         userType: user.userType,
         employeeRole: null,
         locationId: null,
+        locationName: null,
+        locationCity: null,
+        locationAddress: null,
       };
     } catch (error) {
       if (error instanceof TRPCError) {


### PR DESCRIPTION
## What & why

When logged into the admin portal as an employee, it wasn't obvious that you're an associate/manager or which single location you're scoped to. This adds a clear, persistent indicator to the top header (navbar).

## Changes

**API — `packages/admin-api/src/router/user.ts`**
Extended `getCurrentUserDetails` to also return the scoped location details via the `employeeAccount.location` relation. Existing fields (`userType`, `employeeRole`, `locationId`) are unchanged so `sidebar.tsx` keeps working. Corporate/customer branches return `null` for the new fields.

New shape:
```ts
// EMPLOYEE
{ userType, employeeRole, locationId, locationName, locationCity, locationAddress }
// CORPORATE / CUSTOMER
{ userType, employeeRole: null, locationId: null, locationName: null, locationCity: null, locationAddress: null }
```

**New client component — `apps/admin-portal/src/app/_components/navbar/user-scope-badge.tsx`**
- Employee: `Manager · <location>` / `Associate · <location>` with a `MapPin` icon making it clear they're limited to that one location. Full "name, city" shown in the badge `title` tooltip.
- Corporate: `Corporate · All locations` with a `Building2` icon.
- Loading or plain customer/unknown: renders `null`.
- Uses `@ebox/ui` `Badge` + `lucide-react` icons, and the `EmployeeRole`/`UserType` enums from `@prisma/client`.

**Navbar — `apps/admin-portal/src/app/_components/navbar/index.tsx`**
Renders `<UserScopeBadge />` at the start of the header, before the existing right-aligned (`ml-auto`) control cluster. Existing controls untouched.

## Validation
- `pnpm -F @ebox/admin-api build` — succeeded (regenerates dist so admin-portal sees the new field).
- `pnpm -F @ebox/admin-api typecheck` — passed, no errors.
- `pnpm -F @ebox/admin-portal typecheck` — the only errors are pre-existing on clean `qa` (verified via `git stash`): `next.config.js`, `seed-analytics.ts`, `employee-home.tsx`, `customer-details` page, `sign-in` page. Zero errors originate from the files in this PR.
- `pnpm lint` intentionally not run (broken repo-wide, pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)